### PR TITLE
[SW-62] Footer icons stay orange when clicked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Created Launch App page
 - Created Hamburger Menu
 - Created Footer
+- Created Footer links
 - Added Desktop Guardian
 - Populated home
 - Transitions between pages

--- a/src/components/common/FooterInfoLink.vue
+++ b/src/components/common/FooterInfoLink.vue
@@ -46,10 +46,6 @@ export default {
   cursor: pointer;
 }
 
-.footer-info-link:hover {
-  color: var(--main-icon-hover-color);
-}
-
 .active {
   animation: orange-flash 0.5s;
 }


### PR DESCRIPTION
## Ticket

[SW-62](https://trello.com/c/XGKlqvJM/64-sw-62-footer-icons-stay-orange-when-clicked)

## Tasks

- Footer icons stay orange when clicked
